### PR TITLE
margin bottom option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ that will be called whenever the context menu is closed.
 </div>
 ```
 
+#### Margin bottom
+
+Add the following attribute to the `context-menu` element: `context-menu-margin-bottom` to keep the context menu
+away from the bottom of the page at least by this attribute value in pixels.
+
+```html
+<div context-menu context-menu-margin-bottom="10">
+<!-- ... -->
+</div>
+```
+
+---
+
 ---
 
 I hope you find this useful!  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-context-menu",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An AngularJS directive to display a context menu when a right-click event is triggered",
   "keywords": [
     "ng-context-menu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-context-menu",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An AngularJS directive to display a context menu when a right-click event is triggered",
   "main": "index.html",
   "devDependencies": {

--- a/public/template/home.html
+++ b/public/template/home.html
@@ -3,6 +3,7 @@
 <div ng-repeat="panel in panels">
   <div context-menu="onRightClick(message)"
        context-menu-close="onClose(closeMessage)"
+       context-menu-margin-bottom="10"
        id="panel-{{ $index }}"
        class="panel panel-default"
        data-target="menu-{{ $index }}"

--- a/src/ng-context-menu.js
+++ b/src/ng-context-menu.js
@@ -1,5 +1,5 @@
 /**
- * ng-context-menu - v1.0.1 - An AngularJS directive to display a context menu
+ * ng-context-menu - v1.0.2 - An AngularJS directive to display a context menu
  * when a right-click event is triggered
  *
  * @author Ian Kennington Walter (http://ianvonwalter.com)
@@ -24,7 +24,8 @@
           scope: {
             'callback': '&contextMenu',
             'disabled': '&contextMenuDisabled',
-            'closeCallback': '&contextMenuClose'
+            'closeCallback': '&contextMenuClose',
+            'marginBottom': '@contextMenuMarginBottom'
           },
           link: function($scope, $element, $attrs) {
             var opened = false;
@@ -51,7 +52,8 @@
               }
 
               if (totalHeight > docHeight) {
-                top = top - (totalHeight - docHeight);
+                var marginBottom = $scope.marginBottom || 0;
+                top = top - (totalHeight - docHeight) - marginBottom;
               }
 
               menuElement.css('top', top + 'px');


### PR DESCRIPTION
Suggesting to add an margin bottom attribute to keep the context menu away from the bottom of the page at least by this attribute value in pixels.

Pros: it is beautiful :) and it can be used in applications with fixed always-on-top footer (these applications often need custom context menu).