### PR TITLE
added directive clickForContextMenu to assist in opening context menu on touchscreen devices

### DIFF
--- a/src/ng-context-menu.js
+++ b/src/ng-context-menu.js
@@ -15,6 +15,11 @@
         menuElement: null
       };
     })
+    .controller('ContextMenuController', function () {
+      this.init = function (clicked) {
+        this.clicked = clicked;
+      }
+    })
     .directive('contextMenu', [
       '$document',
       'ContextMenuService',
@@ -69,7 +74,7 @@
               opened = false;
             }
 
-            $element.bind('contextmenu', function(event) {
+            function clicked(event) {
               if (!$scope.disabled()) {
                 if (ContextMenuService.menuElement !== null) {
                   close(ContextMenuService.menuElement);
@@ -89,7 +94,10 @@
                   open(event, ContextMenuService.menuElement);
                 });
               }
-            });
+            }
+
+            contextMenuController.init(clicked);
+            $element.bind('contextmenu', clicked);
 
             function handleKeyUpEvent(event) {
               //console.log('keyup');
@@ -126,5 +134,16 @@
           }
         };
       }
-    ]);
+    ])
+    .directive('clickForContextMenu', function() {
+      return {
+        restrict: 'CA',
+        require: '^contextMenu',
+        link: function (scope, element, attrs, contextMenuController) {
+          element.bind('click', function (event) {
+            contextMenuController.clicked(event);
+          })
+        }
+      }
+    });
 })(angular);


### PR DESCRIPTION
This adds a directive called clickForContextMenu which can be used on an element within another element with the contextMenu directive.
```
<div class="some-info" context-menu data-target="my-target" >
  <span ng-click="someDefaultOption">Here is some text</span>
  <i click-for-context-menu class="my-menu-icon pointer"></i>
</div>```
This way you can embed a sub-element anywhere within a contextMenu which acts as a button to open the menu on devices which don't easily support context menus.